### PR TITLE
Modify company identification regex to accept letters

### DIFF
--- a/examples/ach/records/batch_control_example.rb
+++ b/examples/ach/records/batch_control_example.rb
@@ -39,4 +39,25 @@ describe ACH::Records::BatchControl do
     lambda { @record.company_identification_code_designator = 'A' }.should_not raise_error
   end
 
+  describe 'batch control - company identification' do
+    it 'should allow for numeric values' do
+      lambda { @record.company_identification = '012345678' }.should_not raise_error
+    end
+
+    it 'should allow for alphanumeric values, with a leading letter' do
+      lambda { @record.company_identification = 'A12345678' }.should_not raise_error
+    end
+
+    it 'should not allow for multiple letters' do
+      lambda { @record.company_identification = 'AA1234567' }.should raise_error
+    end
+
+    it 'should not allow invalid length, 6 digits' do
+      lambda { @record.company_identification = '123456' }.should raise_error
+    end
+
+    it 'should not allow invalid length, 10 digits' do
+      lambda { @record.company_identification = '1234567890' }.should raise_error
+    end
+  end
 end

--- a/examples/ach/records/batch_header_example.rb
+++ b/examples/ach/records/batch_header_example.rb
@@ -28,6 +28,26 @@ describe ACH::Records::BatchHeader do
       lambda { @record.standard_entry_class_code = 'CCD' }.should_not raise_error(RuntimeError)
     end
 
-    it 'should be limited to real codes'
+    describe 'batch header - company identification' do
+      it 'should allow for numeric values' do
+        lambda { @record.company_identification = '012345678' }.should_not raise_error
+      end
+
+      it 'should allow for alphanumeric values, with a leading letter' do
+        lambda { @record.company_identification = 'A12345678' }.should_not raise_error
+      end
+
+      it 'should not allow for multiple letters' do
+        lambda { @record.company_identification = 'AA1234567' }.should raise_error
+      end
+
+      it 'should not allow invalid length, 6 digits' do
+        lambda { @record.company_identification = '123456' }.should raise_error
+      end
+
+      it 'should not allow invalid length, 10 digits' do
+        lambda { @record.company_identification = '1234567890' }.should raise_error
+      end
+    end
   end
 end

--- a/lib/ach/records/batch_control.rb
+++ b/lib/ach/records/batch_control.rb
@@ -16,7 +16,7 @@ module ACH::Records
     field :company_identification_code_designator, String, nil, '1',
         /\A[0-9A-Z ]\z/
     field :company_identification, String,
-        lambda { |f| f.rjust(9) }, nil, /\A\d{7,9}\z/
+        lambda { |f| f.rjust(9) }, nil, /\A[\dA-Z]\d{6,8}\z/
 
     field :message_authentication_code, String,
         lambda { |f| left_justify(f, 19)}, ''

--- a/lib/ach/records/batch_header.rb
+++ b/lib/ach/records/batch_header.rb
@@ -14,7 +14,7 @@ module ACH::Records
     field :company_identification_code_designator, String, nil, '1',
         /\A[0-9A-Z ]\z/
     field :company_identification, String,
-        lambda { |f| f.rjust(9) }, nil, /\A\d{7,9}\z/
+        lambda { |f| f.rjust(9) }, nil, /\A[\dA-Z]\d{6,8}\z/
     # TODO This should be used to determine whether other records are valid for
     # this code. Should there be a Class for each code?
     # The default of PPD is purely for my benefit (Jared Morgan)

--- a/lib/ach/version.rb
+++ b/lib/ach/version.rb
@@ -1,3 +1,3 @@
 module ACH
-  VERSION = '0.4.4'.freeze
+  VERSION = '0.4.5'.freeze
 end


### PR DESCRIPTION
- Modify batch headers and control regex to accept any string with:
  first value A-Z, followed by 6-8 digits OR any string with 7-9 digits.
- add regex unit tests
